### PR TITLE
FEATURE(account): Add a conscience slots managment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An Ansible role for install and configure a servicetype account.
 | `openio_account_sentinel_master_name` | `"{{ openio_account_namespace }}-master-1"` | Sentinel master name (not compatible with `openio_account_redis_standalone`) |
 | `openio_account_sentinels_hosts` | `` | List of sentinels <IP:PORT> |
 | `openio_account_serviceid` | `"0"` | ID in gridinit |
+| `openio_account_slots` | `[account]` | The service's slot in conscience |
 | `openio_account_version` | `latest` | Install a specific version |
 | `openio_account_workers` | `` | Number of worker (default if empty) |
 | `openio_account_provision_only` | `false` | Provision only without restarting services |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,4 +26,9 @@ openio_account_gridinit_dir: "/etc/gridinit.d/{{ openio_account_namespace }}"
 openio_account_gridinit_file_prefix: ""
 
 openio_account_provision_only: false
+
+openio_account_slots:
+  "{{ [ openio_account_type, openio_account_type ~ '-' ~ openio_account_location.split('.')[:-2] | join('-') ] \
+  if openio_account_location.split('.') | length > 2 \
+  else [ openio_account_type ] }}"
 ...

--- a/templates/account.conf.j2
+++ b/templates/account.conf.j2
@@ -15,6 +15,6 @@ log_facility = {{ openio_account_log_facility }}
 log_address = {{ openio_account_log_address }}
 syslog_prefix = OIO,{{ openio_account_namespace }},account,{{ openio_account_serviceid }}
 autocreate = true
-{% if openio_account_workers %}workers = {{ openio_account_workers }}{% endif %}
+{% if openio_account_workers is defined and openio_account_workers %}workers = {{ openio_account_workers }}{% endif %}
 
-{% if openio_account_backlog %}backlog = {{ openio_account_backlog }}{% endif %}
+{% if openio_account_backlog is defined and openio_account_backlog %}backlog = {{ openio_account_backlog }}{% endif %}

--- a/templates/watch-account.yml.j2
+++ b/templates/watch-account.yml.j2
@@ -2,7 +2,7 @@
 ---
 host: {{ openio_account_bind_address }}
 port: {{ openio_account_bind_port }}
-type: account
+type: {{ openio_account_type }}
 {% if openio_account_location | ipaddr %}
 location: {{ openio_account_location | replace(".", "-") }}
 {% else %}
@@ -13,4 +13,6 @@ checks:
 stats:
   - {type: http, path: /status, parser: json}
   - {type: system}
+slots:
+  {{ openio_account_slots | to_nice_yaml | indent(2) }}
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 openio_account_sysconfig_dir: "/etc/oio/sds/{{ openio_account_namespace }}"
 openio_account_servicename: "account-{{ openio_account_serviceid }}"
+openio_account_type: account
 
 openio_account_definition_file: >
   "{{ openio_account_sysconfig_dir }}/


### PR DESCRIPTION
 ##### ISSUE TYPE
- Feature

 ##### SUMMARY
Add slots for multisite deployments

 ##### SCOPE (skeleton only)
- account

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Currently slots are unmanaged.
This commit add a default slot (servicetype's name).
For location superior to 2, a slot is added based on the first two locations

examples:
location:
  - host.id            slots => [account]
  - site.host.id       slots => [account, account-site]
  - region.site.host.id  slots => [account, account-region-site]