### PR TITLE
BUGFIX/MINOR(account): Fix the use of tags `install` and `configure`

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -11,4 +11,5 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 ...

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -11,4 +11,5 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,9 @@
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
-  tags: install
+  tags:
+    - install
+    - configure
 
 - name: "Include {{ ansible_distribution }} tasks"
   include_tasks: "{{ item }}"
@@ -28,7 +30,7 @@
     - path: "/var/log/oio/sds/{{ openio_account_namespace }}/{{ openio_account_servicename }}"
       owner: "{{ syslog_user }}"
       mode: "0750"
-  tags: install
+  tags: configure
 
 - name: Generate configuration files
   template:
@@ -47,6 +49,7 @@
     - src: "watch-account.yml.j2"
       dest: "{{ openio_account_sysconfig_dir }}/watch/{{ openio_account_servicename }}.yml"
   register: _account_conf
+  tags: configure
 
 - name: "restart account to apply the new configuration"
   shell: |
@@ -78,6 +81,7 @@
       delay: 5
       until: _account_check is success
       changed_when: false
+      tags: configure
       when:
         - not openio_account_provision_only
   when: openio_bootstrap | d(false)


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION