### PR TITLE
CHANGE(account): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ An Ansible role for install and configure a servicetype account.
 | `openio_account_version` | `latest` | Install a specific version |
 | `openio_account_workers` | `` | Number of worker (default if empty) |
 | `openio_account_provision_only` | `false` | Provision only without restarting services |
+| `openio_account_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,7 @@ openio_account_gridinit_dir: "/etc/gridinit.d/{{ openio_account_namespace }}"
 openio_account_gridinit_file_prefix: ""
 
 openio_account_provision_only: false
+openio_account_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 
 openio_account_slots:
   "{{ [ openio_account_type, openio_account_type ~ '-' ~ openio_account_location.split('.')[:-2] | join('-') ] \

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_account_package_upgrade else 'present' }}"
   with_items: "{{ account_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_account_package_upgrade else 'present' }}"
   with_items: "{{ account_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION