### PR TITLE
BUGFIX/MINOR(account): Manage socket timeouts to redis and `max_connections` to sentinel

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,16 @@ openio_account_sentinel_master_name: "{{ openio_account_namespace }}-master-1"
 
 openio_account_redis_inventory_groupname: redis
 openio_account_redis_standalone: ""
+openio_account_redis_socket_timeout: "60"
+openio_account_redis_socket_connect_timeout: "3"
+openio_account_redis_socket_keepalive: false
+openio_account_redis_retry_on_timeout: false
+openio_account_redis_max_connections: "2**18"
+openio_account_sentinel_socket_timeout: "5"
+openio_account_sentinel_socket_connect_timeout: "3"
+openio_account_sentinel_socket_keepalive: "{{ openio_account_redis_socket_keepalive }}"
+openio_account_sentinel_retry_on_timeout: "{{ openio_account_redis_retry_on_timeout }}"
+openio_account_sentinel_max_connections: "{{ openio_account_redis_max_connections }}"
 
 openio_account_log_level: INFO
 openio_account_log_facility: LOG_LOCAL0

--- a/templates/account.conf.j2
+++ b/templates/account.conf.j2
@@ -18,3 +18,18 @@ autocreate = true
 {% if openio_account_workers is defined and openio_account_workers %}workers = {{ openio_account_workers }}{% endif %}
 
 {% if openio_account_backlog is defined and openio_account_backlog %}backlog = {{ openio_account_backlog }}{% endif %}
+
+# Redis parameters (see redis.connection module)
+redis_socket_timeout={{ openio_account_redis_socket_timeout }}
+redis_socket_connect_timeout={{ openio_account_redis_socket_connect_timeout }}
+redis_socket_keepalive={{ openio_account_redis_socket_keepalive }}
+redis_retry_on_timeout={{ openio_account_redis_retry_on_timeout }}
+redis_max_connections={{ openio_account_redis_max_connections }}
+
+# Redis sentinel parameters, override Redis parameters
+# for connections to the sentinels.
+redis_sentinel_socket_timeout={{ openio_account_sentinel_socket_timeout }}
+redis_sentinel_socket_connect_timeout={{ openio_account_sentinel_socket_connect_timeout }}
+redis_sentinel_socket_keepalive={{ openio_account_sentinel_socket_keepalive }}
+redis_sentinel_retry_on_timeout={{ openio_account_sentinel_retry_on_timeout }}
+redis_sentinel_max_connections={{ openio_account_sentinel_max_connections }}


### PR DESCRIPTION
 ##### SUMMARY
This PR allows to configure timeouts of redis, which are by default too high.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
[root@5ce3a6adc421 /]# cat /etc/oio/sds/TRAVIS/account-0/account-0.conf
[account-server]
bind_addr = 172.17.0.5
bind_port = 6009
redis_host = 172.17.0.5
redis_port = 6011
log_level = INFO
log_facility = LOG_LOCAL0
log_address = /dev/log
syslog_prefix = OIO,TRAVIS,account,0
autocreate = true

redis_socket_timeout=1
redis_socket_connect_timeout=1
redis_socket_keepalive=False
redis_retry_on_timeout=False
redis_max_connections=2**31

redis_sentinel_socket_timeout=1
redis_sentinel_socket_connect_timeout=1
redis_sentinel_socket_keepalive=False
redis_sentinel_retry_on_timeout=False
redis_sentinel_max_connections=2**31
```