### PR TITLE
BUGFIX/MAJOR(SDS): Fix syntax error introduced in 1de6231

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,7 +25,7 @@ openio_account_redis_socket_timeout: "60"
 openio_account_redis_socket_connect_timeout: "3"
 openio_account_redis_socket_keepalive: false
 openio_account_redis_retry_on_timeout: false
-openio_account_redis_max_connections: "2**18"
+openio_account_redis_max_connections: "262144" #2**18
 openio_account_sentinel_socket_timeout: "5"
 openio_account_sentinel_socket_connect_timeout: "3"
 openio_account_sentinel_socket_keepalive: "{{ openio_account_redis_socket_keepalive }}"


### PR DESCRIPTION
 ##### SUMMARY

The previous commit introduced an erroneous syntax.
The default is now setted to an evaluated value.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
[openio@8e6ffba23d5b ~]$ /usr/bin/oio-account-server /etc/oio/sds/JENKINS/account-0/account-0.conf
Traceback (most recent call last):
  File "/usr/bin/oio-account-server", line 33, in <module>
    app = create_app(conf)
  File "/usr/lib/python3.6/site-packages/oio/account/server.py", line 553, in create_app
    backend = AccountBackend(conf)
  File "/usr/lib/python3.6/site-packages/oio/account/backend.py", line 259, in __init__
    sentinel_name=redis_sentinel_name, **redis_conf)
  File "/usr/lib/python3.6/site-packages/oio/common/redis_conn.py", line 48, in __init__
    self._conn_kwargs = self._filter_conn_kwargs(kwargs)
  File "/usr/lib/python3.6/site-packages/oio/common/redis_conn.py", line 81, in _filter_conn_kwargs
    for k, v in conn_kwargs.items()
  File "/usr/lib/python3.6/site-packages/oio/common/redis_conn.py", line 82, in <dictcomp>
    if k in parsers}
ValueError: invalid literal for int() with base 10: '2**18'
```